### PR TITLE
Chrome manifest v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,10 @@ This will make a fine addition to your security and privacy digital tool belt.
 ## Build
 
 Use the Makefile with the command `make` to prepare this extension. Files are copied and prepared within the `dist/` directory.
+
+## The Design
+
+The extension has three layers:
+Background -> content-script -> injected-script
+
+The content script acts as a proxy for messages to the backend script. This is required for features that need access to `chrome.*` APIs under the more secure Chrome Manifest V3.

--- a/src/contentScript.css
+++ b/src/contentScript.css
@@ -32,6 +32,22 @@
 	height:14px;
 }
 
+.ClIconPadlockLocked {
+	content: url('chrome-extension://__MSG_@@extension_id__/images/green-padlock.png');
+}
+.ClIconEmail {
+	content: url('chrome-extension://__MSG_@@extension_id__/images/email-icon.png');
+}
+.ClIconJS {
+	content: url('chrome-extension://__MSG_@@extension_id__/images/JS-icon.png');
+}
+.ClIconHourglass {
+	content: url('chrome-extension://__MSG_@@extension_id__/images/hourglass.svg');
+}
+.ClIconHourglassBroken {
+	content: url('chrome-extension://__MSG_@@extension_id__/images/BrokenGlass.png');
+}
+
 .ClLoading{
 	animation:ClLoadingAnimation 1s infinite;
 }

--- a/src/contentScriptActivationFilter.js
+++ b/src/contentScriptActivationFilter.js
@@ -1,5 +1,40 @@
-// Check (before load event) if this webpage should have the extension injected.
+// Check (before load event, if possible) if this webpage should have the extension injected.
 // Background script will decide (looking at user options).
 // Allows users to blacklist/whitelist sites.
 // Also reduces overall CPU/RAM usage, at the cost of a few additional cycles on each pages startup.
-chrome.runtime.sendMessage({ activationHostname: window.location.hostname });
+(async () => {
+  const response = await chrome.runtime.sendMessage({ activationHostname: window.location.hostname });
+  if(response?.inject) {
+    initialise();
+  }
+})();
+
+/**
+ * Initialise the content script.
+ * Set up message passing between injected script, this content script, and background script.
+ * Access to chrome.* APIs is not available in the injected script, this content script acts as a proxy.
+ */
+function initialise() {
+  // Setup message passing.
+  window.addEventListener('message', async (event) => {
+    // We only accept messages from ourselves
+    if (event.source !== window) {
+      return;
+    }
+    // Determine type of event
+    if (event.data.type && (event.data.type === 'FROM_PAGE_SHORT_URL')) {
+      // Request backend to expand the short URL
+      const response = await chrome.runtime.sendMessage(event.data.message);
+      // Return the response to the injected script
+      window.postMessage({type : 'TO_PAGE_EXPANDED_SHORT_URL', message : response}, '*');
+    }
+  }, false);
+
+  // Listen for synced-user-options changes
+  chrome.storage.onChanged.addListener(function(changes, namespace) {
+    if(namespace === 'sync') {
+      // Send changes to injected script
+      window.postMessage({type : 'TO_PAGE_SYNC_USER_OPTIONS_CHANGED', message : changes}, '*');
+    }
+  });
+}

--- a/src/contentScriptActivationFilter.js
+++ b/src/contentScriptActivationFilter.js
@@ -2,39 +2,4 @@
 // Background script will decide (looking at user options).
 // Allows users to blacklist/whitelist sites.
 // Also reduces overall CPU/RAM usage, at the cost of a few additional cycles on each pages startup.
-(async () => {
-  const response = await chrome.runtime.sendMessage({ activationHostname: window.location.hostname });
-  if(response?.inject) {
-    initialise();
-  }
-})();
-
-/**
- * Initialise the content script.
- * Set up message passing between injected script, this content script, and background script.
- * Access to chrome.* APIs is not available in the injected script, this content script acts as a proxy.
- */
-function initialise() {
-  // Setup message passing.
-  window.addEventListener('message', async (event) => {
-    // We only accept messages from ourselves
-    if (event.source !== window) {
-      return;
-    }
-    // Determine type of event
-    if (event.data.type && (event.data.type === 'FROM_PAGE_SHORT_URL')) {
-      // Request backend to expand the short URL
-      const response = await chrome.runtime.sendMessage(event.data.message);
-      // Return the response to the injected script
-      window.postMessage({type : 'TO_PAGE_EXPANDED_SHORT_URL', message : response}, '*');
-    }
-  }, false);
-
-  // Listen for synced-user-options changes
-  chrome.storage.onChanged.addListener(function(changes, namespace) {
-    if(namespace === 'sync') {
-      // Send changes to injected script
-      window.postMessage({type : 'TO_PAGE_SYNC_USER_OPTIONS_CHANGED', message : changes}, '*');
-    }
-  });
-}
+chrome.runtime.sendMessage({ activationHostname: window.location.hostname });

--- a/src/contentScriptLoader.js
+++ b/src/contentScriptLoader.js
@@ -1,7 +1,0 @@
-(async () => {
-    // Chrome extensions do not allow JS modules to be executed, so need to dynamically import the content script.
-    const src = chrome.extension.getURL('contentScript.js');
-    const contentScript = await import(src);
-    // Initialise content script with default settings.
-    contentScript.initialise();
-})();

--- a/src/contentScriptLoaderForOptionsPage.js
+++ b/src/contentScriptLoaderForOptionsPage.js
@@ -1,36 +1,16 @@
 import { defaultSettings } from './defaultSettings.js';
+import { initAllSharedListeners } from './contentScriptSharedLib.js';
 
 (async () => {
   // Chrome extensions do not allow JS modules to be executed, so need to dynamically import the content script.
   const src = chrome.runtime.getURL('contentScript.js');
   const contentScript = await import(src);
   // Load synced settings (e.g. user preferences)
-  const settings = await chrome.storage.sync.get(defaultSettings); // TODO errors! JS module not loaded.
+  const settings = await chrome.storage.sync.get(defaultSettings);
+
   // Initialise content script.
   // Options page should not cache Short URLs to enable user to test with example short URLs given in the Options page.
   contentScript.initialise(settings, false);
-
-  // TODO - Move this to a JS module for contentScript Message Passing (to reduce code duplication in contentScriptActivationFilter.js and contentScriptLoaderForOptionsPage.js)
-  // Setup message passing.
-  window.addEventListener('message', async (event) => {
-    // We only accept messages from ourselves
-    if (event.source !== window) {
-      return;
-    }
-    // Determine type of event
-    if (event.data.type && (event.data.type === 'FROM_PAGE_SHORT_URL')) {
-      // Request backend to expand the short URL
-      const response = await chrome.runtime.sendMessage(event.data.message);
-      // Return the response to the injected script
-      window.postMessage({type : 'TO_PAGE_EXPANDED_SHORT_URL', message : response}, '*');
-    }
-  }, false);
-
-  // Listen for synced-user-options changes
-  chrome.storage.onChanged.addListener(function(changes, namespace) {
-    if(namespace === 'sync') {
-      // Send changes to injected script
-      window.postMessage({type : 'TO_PAGE_SYNC_USER_OPTIONS_CHANGED', message : changes}, '*');
-    }
-  });
+  // Setup message passing and related listeners.
+  initAllSharedListeners();
 })();

--- a/src/contentScriptLoaderForOptionsPage.js
+++ b/src/contentScriptLoaderForOptionsPage.js
@@ -1,8 +1,36 @@
+import { defaultSettings } from './defaultSettings.js';
+
 (async () => {
-    // Chrome extensions do not allow JS modules to be executed, so need to dynamically import the content script.
-    const src = chrome.extension.getURL('contentScript.js');
-    const contentScript = await import(src);
-    // Initialise content script.
-    // Options page should not cache Short URLs to enable user to test with example short URLs given in the Options page.
-    contentScript.initialise(false);
+  // Chrome extensions do not allow JS modules to be executed, so need to dynamically import the content script.
+  const src = chrome.runtime.getURL('contentScript.js');
+  const contentScript = await import(src);
+  // Load synced settings (e.g. user preferences)
+  const settings = await chrome.storage.sync.get(defaultSettings); // TODO errors! JS module not loaded.
+  // Initialise content script.
+  // Options page should not cache Short URLs to enable user to test with example short URLs given in the Options page.
+  contentScript.initialise(settings, false);
+
+  // TODO - Move this to a JS module for contentScript Message Passing (to reduce code duplication in contentScriptActivationFilter.js and contentScriptLoaderForOptionsPage.js)
+  // Setup message passing.
+  window.addEventListener('message', async (event) => {
+    // We only accept messages from ourselves
+    if (event.source !== window) {
+      return;
+    }
+    // Determine type of event
+    if (event.data.type && (event.data.type === 'FROM_PAGE_SHORT_URL')) {
+      // Request backend to expand the short URL
+      const response = await chrome.runtime.sendMessage(event.data.message);
+      // Return the response to the injected script
+      window.postMessage({type : 'TO_PAGE_EXPANDED_SHORT_URL', message : response}, '*');
+    }
+  }, false);
+
+  // Listen for synced-user-options changes
+  chrome.storage.onChanged.addListener(function(changes, namespace) {
+    if(namespace === 'sync') {
+      // Send changes to injected script
+      window.postMessage({type : 'TO_PAGE_SYNC_USER_OPTIONS_CHANGED', message : changes}, '*');
+    }
+  });
 })();

--- a/src/contentScriptSharedLib.js
+++ b/src/contentScriptSharedLib.js
@@ -1,0 +1,46 @@
+/**
+ * This file contains code that is shared between the content script and
+ * the content script loader for the options page.
+ */
+
+/**
+ * Initialise shared functionality for the content script.
+ * Set up message passing between injected script, this content script, and background script.
+ * Access to chrome.* APIs is not available in the injected script, this content script acts as a proxy.
+ * Also sets up related listeners.
+ */
+export function initAllSharedListeners() {
+  setupMessagePassing();
+  listenForSettingsChanges();
+}
+
+/**
+ * Prepare message passing between injected script, the content script, and background script.
+ */
+export function setupMessagePassing() {
+  window.addEventListener('message', async (event) => {
+    // We only accept messages from ourselves
+    if (event.source !== window) {
+      return;
+    }
+    // Determine type of event
+    if (event.data.type && (event.data.type === 'FROM_PAGE_SHORT_URL')) {
+      // Request backend to expand the short URL
+      const response = await chrome.runtime.sendMessage(event.data.message);
+      // Return the response to the injected script
+      window.postMessage({type : 'TO_PAGE_EXPANDED_SHORT_URL', message : response}, '*');
+    }
+  }, false);
+}
+
+/**
+ * Listen for changes to synced user options.
+ */
+export function listenForSettingsChanges() {
+  chrome.storage.onChanged.addListener((changes, namespace) => {
+    if(namespace === 'sync') {
+      // Send changes to injected script
+      window.postMessage({type : 'TO_PAGE_SYNC_USER_OPTIONS_CHANGED', message : changes}, '*');
+    }
+  });
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "Clear Links",
     "version": "2.1.4",
 	"author": "Christopher Bull",
@@ -12,11 +12,12 @@
 	"permissions": [
 		"storage",
 		"identity",
-		"webNavigation",
+		"webNavigation"
+	],
+	"host_permissions": [
 		"http://*/",
         "https://*/"
 	],
-	"content_security_policy": "script-src 'self' blob: filesystem: chrome-extension-resource: https://apis.google.com; object-src 'self'",
 	"key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgv1hEzO8elR0XP9jiGtSDApjag3UXFSbH/37/kubWHJPqVbNC+WNLiW2OQpInn8eoRUMVGWUVgfJysGsXCr8cf8xRvnGrDJKRgKQB67spzCbEtfj9fqR2FQhcg4mSFPwsy/OygXEWlrzjkENcZbf53oMDGspl6cMa0r8P+rwsxLGjdxEcZ4YQTTYZ3D2BflmcjLtgBOj5vtEPyL3adxuMG6v5+lu5JWqbayJSA2oysk+L19BQuTaMnXcb/j0s50PSQUa7LnkMMggijKTAm67Mj59iggbQVYcL4zu0KLztFrCJ5Xuy60JJgWKNMETukNy448yq5jzpKWfgWvtAlEI8QIDAQAB",
 	"oauth2": {
 		"client_id": "183253452276-9ldchuigo09bhm1frm5ms2ll7109mgr4.apps.googleusercontent.com",
@@ -25,17 +26,22 @@
 		]
 	},
 	"web_accessible_resources": [
+		{
+		  "resources": [
 		"images/*",
 		"contentScript.js",
-		"defaultSettings.js"
+		  ],
+		  "matches": [
+			"*://*/*"
+		  ]
+		}
 	],
 	"background": {
-		"page": "background.html",
-		"persistent": false
+		"service_worker": "background.js",
+		"type": "module"
 	},
 	"options_ui": {
-		"page": "options.html",
-		"chrome_style": true
+		"page": "options.html"
 	},
 	"content_scripts": [
         {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
         "128": "icon128.png"
     },
 	"permissions": [
+		"scripting",
 		"storage",
 		"identity",
 		"webNavigation"
@@ -28,11 +29,14 @@
 	"web_accessible_resources": [
 		{
 		  "resources": [
-		"images/*",
-		"contentScript.js",
+			"images/*",
+			"contentScript.css",
+			"contentScript.js",
+			"defaultSettings.js",
+			"jquery-2.2.3.min.js"
 		  ],
 		  "matches": [
-			"*://*/*"
+			"<all_urls>"
 		  ]
 		}
 	],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -32,6 +32,7 @@
 			"images/*",
 			"contentScript.css",
 			"contentScript.js",
+			"contentScriptSharedLib.js",
 			"defaultSettings.js",
 			"jquery-2.2.3.min.js"
 		  ],


### PR DESCRIPTION
Upgraded the Manifest and related files to Chrome's Manifest V3.

- The manifest file has been updated to adopt the new v3 schema.
- Background script converted into a service worker.
- Improved architecture and added message passing between the injected script (Main World, no `chrome.*` access), the content script (Isolated World, but has `chrome.*` access), and the background service worker.

This resolves #3.

_Known issues:_
Google authentication and expansion of `goo.gl` short links needs upgrading and does not function in the Options page due to the enhanced security from Manifest V3 around remote code execution/downloading--I approve of this change and find it mildly amusing that the enhanced security will only affect a Google-based feature after this upgrade. The expansion of `goo.gl` URLs feature will be upgraded to work within Chrome's Manifest V3 or removed if an upgrade is not feasible (should be fine). The current implementation uses [Google's recently deprecated (March'23) authentication library](https://developers.google.com/identity/sign-in/web/deprecation-and-sunset).