### PR TITLE
Remove jquery from contentscript

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -62,12 +62,6 @@ function injectExtension(tabID, hostname) {
       files: [ 'contentScript.css' ],
       target: { allFrames: true, tabId: tabID },
     });
-    // Inject jQuery and wait before injecting the main content script
-    await chrome.scripting.executeScript({
-      files : [ 'jquery-2.2.3.min.js' ],
-      target : { tabId : tabID, allFrames: true },
-      world: chrome.scripting.ExecutionWorld.MAIN,
-    });
     // Add to Content Script (part of the Isolated World)
     chrome.scripting.executeScript({
       target: { tabId: tabID, allFrames: true },

--- a/src/contentScript.css
+++ b/src/contentScript.css
@@ -7,7 +7,8 @@
 
 #cl-container, .cl-container {
   all: initial;
-  display: none;
+  opacity: 0;
+  transition: opacity 250ms 100ms;
   position: fixed;
   top: 0;
   left: 0;

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -161,37 +161,6 @@ ready(function() {
         break;
     }
   });
-
-  // Attach and detach the tooltip on() <form> <buttons>
-  /* $(document.body).on('mouseenter', 'button', function(e) {
-      showTooltip("btn");
-    })
-    .on('mouseleave', 'button', function(e) {
-      hideTooltip();
-    }); */
-
-  /* // Attach and detach the tooltip on() <form> <buttons>
-    //$(document.body).on('mouseenter', 'input[type="submit"]', function(e) {
-    //$(document.body).on('mouseenter', ':submit', function(e) {
-    $(document.body).on('mouseenter', 'input', function(e) {
-      console.log("Submit button/input");
-      showTooltip("input submit btn");
-    })
-    .on('mouseleave', 'input', function(e) {
-      hideTooltip();
-    }); */
-
-  /* //$('iframe').load(function() {
-    $('#iframeResult').load(function() {
-      console.log('iframe loaded');
-      $('iframe').contents().find('body').on('mouseenter', 'input', function(e) {
-        console.log("In iframe: Submit input field");
-        showTooltip("input btn");
-      })
-      .on('mouseleave', 'input', function(e) {
-        hideTooltip();
-      });
-    }); */
 });
 
 /**
@@ -243,10 +212,6 @@ function formatDissectedURL(href, protocol, username, password, hostname, port, 
     }
     if(settings.displayUrlFragment && hash) {
       urlToDisplay += hash;
-      // Bookmark only links ('#')
-      /* if(href == window.location.href + '#'){
-          showTooltip(domElem, '#', false, false, false);
-        } */
     }
   }
   return urlToDisplay;

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -240,6 +240,7 @@ function formatDissectedURL(href, protocol, username, password, hostname, port, 
 
 function showTooltip(jqDomElem, urlToDisplay, isSecureIcon, isJS, isMailto) {
   const elem = jqDomElem[0]; // TODO temp vanilla const whilst de-jQuerying.
+  const tooltipElem = tooltip[0]; // TODO temp vanilla const whilst de-jQuerying.
   // When compiling the urlToDisplay sent to this function (for https, http, file), some HREFs (in combination with user options) may return an empty string.
   if(urlToDisplay === undefined || urlToDisplay.trim() === '') {
     return;
@@ -259,9 +260,12 @@ function showTooltip(jqDomElem, urlToDisplay, isSecureIcon, isJS, isMailto) {
   });
   // Show the tooltip - check if already attached to document, then attach if not.
   if (document.getElementById(tooltipContainerID) === null) {
-    // Initial attach/Re-attach element - lazily attach element. Some sites detach this element dynamically (i.e. after page load), so fast check on each mouseover.
-    $(document.body).append(tooltip); // Attaching at bottom of document reduces chance of CSS inheritance issues, and stops need to attach/detach after each event.
+    // Initial attach/Re-attach element - lazily attach element upon mouse-over of link.
+    // Some sites detach this element dynamically (i.e. after page load), so check on each mouseover.
+    // Attaching at bottom of document reduces chance of CSS inheritance issues, and stops need to attach/detach after each event.
+    document.body.appendChild(tooltipElem); 
   }
+  // Update tooltip content
   urlText.html(urlToDisplay);
   secureIcon.css('display', (isSecureIcon ? 'inline-block' : 'none'));
   emailIcon.css('display', (isMailto ? 'inline' : 'none'));

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -37,10 +37,24 @@ const urlText = tooltip.children().last();
 // Timers
 let resizeEndTimer; // No native resize end event, so timing our own.
 
+/*
+ * Document ready function.
+ * `DOMContentLoaded` may fire before script/module has a chance to run, so check before adding a listener.
+ * @see https://youmightnotneedjquery.com/#ready
+ * @param {function} fn - The function to be executed when the document is ready.
+ */
+function ready(fn) {
+  if (document.readyState !== 'loading') {
+    fn();
+  } else {
+    document.addEventListener('DOMContentLoaded', fn);
+  }
+}
+
 // Main - Document ready
-$(function() {
+ready(function() {
   // Listen for window size changes
-  $(window).on('resize', function() {
+  addEventListener('resize', () => {
     clearTimeout(resizeEndTimer);
     resizeEndTimer = setTimeout(cacheWinDimensions, 250);
   });
@@ -302,8 +316,8 @@ function applySettingToTooltip(param, value) {
 
 function cacheWinDimensions() {
   winDimensions = {
-    h: $(window).height(),
-    w: $(window).width(),
+    h: window.innerHeight,
+    w: window.innerWidth,
   };
 }
 

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -27,7 +27,8 @@ export function initialise(contentScriptSettings = defaultSettings, cacheShortUr
 let settings;
 let winDimensions;
 // Init the tooltip
-const tooltip = $($.parseHTML('<div id="cl-container"><img src="" alt="Secure protocol used in link" class="cl-icon cl-icon-padlock-locked"></img><img src="" alt="This is a Mailto link" class="cl-icon cl-icon-email"></img><img src="" alt="This link uses Javascript" class="cl-icon cl-icon-js"></img><img src="" alt="Requesting Full URL" class="cl-icon cl-loading cl-icon-hourglass"></img><img src="" alt="Short URL is not expandable" class="cl-icon cl-icon-hourglass-broken"></img><p class="cl-url"></p></div>'));
+const tooltipContainerID = 'cl-container';
+const tooltip = $($.parseHTML('<div id="' + tooltipContainerID + '"><img src="" alt="Secure protocol used in link" class="cl-icon cl-icon-padlock-locked"></img><img src="" alt="This is a Mailto link" class="cl-icon cl-icon-email"></img><img src="" alt="This link uses Javascript" class="cl-icon cl-icon-js"></img><img src="" alt="Requesting Full URL" class="cl-icon cl-loading cl-icon-hourglass"></img><img src="" alt="Short URL is not expandable" class="cl-icon cl-icon-hourglass-broken"></img><p class="cl-url"></p></div>'));
 const secureIcon = tooltip.children().first();
 const emailIcon = secureIcon.next();
 const jsIcon = emailIcon.next();
@@ -233,8 +234,8 @@ function showTooltip(jqDomElem, urlToDisplay, isSecureIcon, isJS, isMailto) {
   const titleAttr = jqDomElem.attr('title');
   // TODO - not necessary if using absolute corner positioning in options
   $(window).mousemove({ hasTooltipAttr: titleAttr !== undefined && titleAttr !== '' }, mouseRelativeCursorPosition);
-  // Show the tooltip
-  if (!$.contains(document, tooltip[0])) { // Fast check
+  // Show the tooltip - check if already attached to document, then attach if not.
+  if (document.getElementById(tooltipContainerID) === null) {
     // Initial attach/Re-attach element - lazily attach element. Some sites detach this element dynamically (i.e. after page load), so fast check on each mouseover.
     $(document.body).append(tooltip); // Attaching at bottom of document reduces chance of CSS inheritance issues, and stops need to attach/detach after each event.
   }

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -276,15 +276,14 @@ function showTooltip(jqDomElem, urlToDisplay, isSecureIcon, isJS, isMailto) {
     jsIcon.css('display', 'none');
   }
 
-  // Attach a specific mouseleave event to the target of the mouseenter event (reduces likelihood of multiple orphaned tooltips when a site interferes with this extension)
-  const localTooltip = tooltip;
-  function localMouseLeave() {
-    // Hide the Tooltip
-    window.removeEventListener('mousemove', wrappedMouseRelativeCursorPosition); // Cancel additional mousemove tracking when not over a link.
-    localTooltip.stop().fadeOut(settings.durationFadeOut); // Hide the locally referenced tooltip (in case of some DOM refreshing wizardry).
-  }
+  // Hide the Tooltip when mouse leaves link.
   // Add a one-time mouseleave event to the link, to cancel additional mousemove tracking when not over a link.
-  elem.addEventListener('mouseleave', localMouseLeave, { once: true });
+  elem.addEventListener('mouseleave', () => {
+    // Cancel additional mousemove tracking when not over a link.
+    window.removeEventListener('mousemove', wrappedMouseRelativeCursorPosition);
+    // Hide the Tooltip.
+    tooltip.stop().fadeOut(settings.durationFadeOut);
+  }, { once: true });
 }
 
 /**


### PR DESCRIPTION
Remove all usage of jQuery from the injected contentScript.

Partially improves #5 and importantly it fixes #13 

JQueryUI is still used in the Options menu, but it runs in its own isolated world and is therefore not a priority yet.