### PR TITLE
Exclude .trunk directory from markdown linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:package:ff": "web-ext build --source-dir dist/firefox --overwrite-dest",
     "lint": "npm run lint:md && npm run lint:css && npm run lint:src && make build_ff_only && npm run lint:web-ext:ff",
     "lint:css": "stylelint \"src/**/*.css\"",
-    "lint:md": "markdownlint-cli2 \"**/*.md\" \"!node_modules\" \"!docs/test-results\" \"!dist\" \"!swark-output\"",
+    "lint:md": "markdownlint-cli2 \"**/*.md\" \"!node_modules\" \"!docs/test-results\" \"!dist\" \"!swark-output\" \"!.trunk\"",
     "lint:src": "eslint src test",
     "lint:web-ext:ff": "web-ext lint --source-dir ./dist/firefox/",
     "release:dry-run": "npx semantic-release --dry-run",


### PR DESCRIPTION
## Summary
Exclude the `.trunk` directory from markdown linting.

## Why
This avoids markdown lint noise from generated or tooling-managed files under `.trunk` and keeps lint results focused on repository source content.